### PR TITLE
Added a writeup for mac-hacking-150

### DIFF
--- a/confidence-ctf-teaser-2015/README.md
+++ b/confidence-ctf-teaser-2015/README.md
@@ -6,16 +6,14 @@
 ## Completed write-ups
 
 * [pwning/quine-400](pwning/quine-400)
-
+* [crypto/mac-hacking-150](crypto/mac-hacking-150)
 
 ## External write-ups only
 
-* (NONE)
+* [crypto/power-level-50](crypto/power-level-50)
 
 ## Missing write-ups
 
-* [crypto/mac-hacking-150](crypto/mac-hacking-150)
-* [crypto/power-level-50](crypto/power-level-50)
 * [crypto/the-real-mac-hacking-400](crypto/the-real-mac-hacking-400)
 * [network/apache-underwear-400](network/apache-underwear-400)
 * [programming/here-be-dragons-300](programming/here-be-dragons-300)

--- a/confidence-ctf-teaser-2015/crypto/mac-hacking-150/README.md
+++ b/confidence-ctf-teaser-2015/crypto/mac-hacking-150/README.md
@@ -13,7 +13,39 @@
 
 ## Write-up
 
-(TODO)
+### Explanation
+
+To do this challenge, we had to understand how HMAC works. HMAC is constructed using the following formula and the hash function used in the challenge was `md5`:
+
+    HMAC(hash, data, key) = hash(key XOR (0x5c repeated 64 times) + hash(key XOR (0x36 repeated 64 times) + data))
+
+The challenge provided us a way to know the output of this where `input` is the value we provide:
+
+    hash(key XOR input)
+	
+The first step was to send the input `(0x36 repeated 64 times) + "123"`. This would give us the value `hash(key XOR (0x36 repeated 64 times) + data)` in the HMAC formula for the data `123`.
+
+    Query: /?a=sign&m=old&d=%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36%36123
+    Output: 2054441aa609e0ff20bc628190e88c40
+	
+But we want to get a value with data that contains `get flag` in it. So we perform a hash length extension attack using the `HashPump` tool.
+
+    Command: hashpump -s '2054441aa609e0ff20bc628190e88c40' --data '123' -a 'get flag' -k 64
+    New hash: 4d6c75e7bb5336ab5dd63d156a0e7db5
+    New data: 123\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18\x02\x00\x00\x00\x00\x00\x00get flag
+	  
+The second step is to know the output of `hash(key XOR (0x5c repeated 64 times) + previous_hash)` where `previous_hash` is the value that we found in the previous step. So we do the same thing we did in the first step but with `0x5c` instead of `0x36`:
+
+    Query: /?a=sign&m=old&d=%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%5c%4d%6c%75%e7%bb%53%36%ab%5d%d6%3d%15%6a%0e%7d%b5
+	Output: 24049ad4b163dd828bd71a8a5f37b642
+	
+The previous output is the HMAC result of the data  `123\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18\x02\x00\x00\x00\x00\x00\x00get flag`. Send it and collect the flag.
+
+   Query: /?a=verify&m=new&d=123%80%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%00%18%02%00%00%00%00%00%00get+flag&s=24049ad4b163dd828bd71a8a5f37b642
+	
+### Flag
+
+DrgnS{MyHardWorkByTheseWordsGuardedPleaseDontStealMasterCryptoProgrammer}
 
 ## Other write-ups and resources
 


### PR DESCRIPTION
I added a writeup for `mac-hacking-150`. `power-level-50` already had an external writeup, but wasn't listed in the main README. I updated that too.