### PR TITLE
:link: External links for DefCon quals: babycmd, babyecho, mathwiz

### DIFF
--- a/defcon-qualifier-ctf-2015/babys-first/babycmd/README.md
+++ b/defcon-qualifier-ctf-2015/babys-first/babycmd/README.md
@@ -20,3 +20,4 @@
 * <http://lockboxx.blogspot.com/2015/05/defcon-ctf-2015-quals-writeup-babycmd.html>
 * <https://gist.github.com/anonymous/052f0cac9b54748fb15c>
 * <http://pastebin.com/vX4L6ebJ>
+* <https://ctf-team.vulnhub.com/defcon-2015-quals-babycmd/>

--- a/defcon-qualifier-ctf-2015/babys-first/babyecho/README.md
+++ b/defcon-qualifier-ctf-2015/babys-first/babyecho/README.md
@@ -18,3 +18,4 @@
 
 * [Korean](http://blackcon.tistory.com/121)
 * <http://pastebin.com/TGuRLGCQ>
+* <https://ctf-team.vulnhub.com/defcon-2015-quals-babyecho/>

--- a/defcon-qualifier-ctf-2015/babys-first/mathwhiz/README.md
+++ b/defcon-qualifier-ctf-2015/babys-first/mathwhiz/README.md
@@ -17,3 +17,4 @@
 * <https://github.com/rick2600/writeups/blob/master/defcon2015/matwiz.md>
 * <http://lockboxx.blogspot.com/2015/05/defcon-ctf-2015-quals-writeup-babycmd.html>
 * <http://pastebin.com/8Nb1Kv7J>
+* <https://ctf-team.vulnhub.com/defcon-2015-quals-mathwhiz/>


### PR DESCRIPTION
Added Team Vulnhub's external link writeups for DefCon Quals.