### PR TITLE
:link: Add external writeup links for defcon

### DIFF
--- a/defcon-qualifier-ctf-2015/babys-first/babycmd/README.md
+++ b/defcon-qualifier-ctf-2015/babys-first/babycmd/README.md
@@ -21,3 +21,4 @@
 * <https://gist.github.com/anonymous/052f0cac9b54748fb15c>
 * <http://pastebin.com/vX4L6ebJ>
 * <https://ctf-team.vulnhub.com/defcon-2015-quals-babycmd/>
+* <http://www.mrt-prodz.com/blog/view/2015/05/def-con-2015-quals---babycmd-1pt-writeup>

--- a/defcon-qualifier-ctf-2015/babys-first/mathwhiz/README.md
+++ b/defcon-qualifier-ctf-2015/babys-first/mathwhiz/README.md
@@ -18,3 +18,4 @@
 * <http://lockboxx.blogspot.com/2015/05/defcon-ctf-2015-quals-writeup-babycmd.html>
 * <http://pastebin.com/8Nb1Kv7J>
 * <https://ctf-team.vulnhub.com/defcon-2015-quals-mathwhiz/>
+* <http://www.mrt-prodz.com/blog/view/2015/05/def-con-2015-quals---mathwhiz-1pt-writeup>

--- a/defcon-qualifier-ctf-2015/reverse/access-control/README.md
+++ b/defcon-qualifier-ctf-2015/reverse/access-control/README.md
@@ -17,3 +17,4 @@
 ## Other write-ups and resources
 
 * <https://github.com/smokeleeteveryday/CTF_WRITEUPS/tree/master/2015/DEFCONCTF/reversing/accesscontrol>
+* <http://www.mrt-prodz.com/blog/view/2015/05/def-con-2015-quals---access-control-1pt-writeup>


### PR DESCRIPTION
Greetings,

Sending 3 writeup for DEF CON Quals 2015: babycmd, mathwhiz and access control.