### PR TITLE
:pill: Fix IceCTF links

### DIFF
--- a/icectf-2015/web-exploitation/hackers-in-disguise/README.md
+++ b/icectf-2015/web-exploitation/hackers-in-disguise/README.md
@@ -16,4 +16,4 @@
 
 ## Other write-ups and resources
 
-* <http://blog.atx.name/icectf/#Hackers in disguise>
+* <http://blog.atx.name/icectf/#Hackers%20in%20disguise>

--- a/icectf-2015/web-exploitation/wiki-and-the-furious/README.md
+++ b/icectf-2015/web-exploitation/wiki-and-the-furious/README.md
@@ -16,4 +16,4 @@
 
 ## Other write-ups and resources
 
-* <http://blog.atx.name/icectf/#Wiki & The Furious>
+* <http://blog.atx.name/icectf/#Wiki%20&%20The%20Furious>


### PR DESCRIPTION
Fix two external write-up links not correctly interpreted by markdown because of the not url-encoded spaces.