### PR TITLE
32C3 config.bin: Changed info link from overview site to article

### DIFF
--- a/32c3-ctf-2015/forensics/config-bin-150/README.md
+++ b/32c3-ctf-2015/forensics/config-bin-150/README.md
@@ -15,4 +15,4 @@
 ## Other write-ups and resources
 
 * <https://github.com/SleepProgger/ctf_stuff/blob/master/32C3/config.bin/crack_config.py>
-* [Information about the fileformat and decrypter @https://heinrichs.io/](https://heinrichs.io/)
+* [Information about the fileformat and decrypter @https://heinrichs.io/](https://heinrichs.io/207)


### PR DESCRIPTION
Pasted the wrong link before, sorry.