### PR TITLE
update 2015 defcon quals scoreboard link

### DIFF
--- a/defcon-qualifier-ctf-2015/README.md
+++ b/defcon-qualifier-ctf-2015/README.md
@@ -1,7 +1,7 @@
 # DEF CON Qualifier CTF write-ups
 
 * <https://2015.legitbs.net/>
-* [Scoreboard](https://2015.legitbs.net/scoreboard) or [local alternative](scoreboard)
+* [Scoreboard](https://legitbs.net/statdump_2015/scoreboard.html) or [local alternative](scoreboard)
 
 ## Completed write-ups
 


### PR DESCRIPTION
we take the scoreboard app down pretty quickly because running it comes right out of my whisky budget, but the URL on our main site is expected to stay